### PR TITLE
Clear mediaChunks every startRecording()

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,6 +137,8 @@ function useMediaRecorder({
     if (!mediaStream.current) {
       await getMediaStream();
     }
+    
+    mediaChunks.current = []
 
     if (mediaStream.current) {
       mediaRecorder.current = new MediaRecorder(


### PR DESCRIPTION
This will allow you to start another recording when you implement record > preview > re-take kind of flow on the same page.