### PR TITLE
Implement timeslice parameter

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -26,7 +26,7 @@ export interface MediaRecorderHookOptions {
   stopRecording: () => void;
   getMediaStream: () => void;
   clearMediaStream: () => void;
-  startRecording: () => void;
+  startRecording: (timeSlice?: number) => void;
   pauseRecording: () => void;
   resumeRecording: () => void;
   muteAudio: () => void;

--- a/index.js
+++ b/index.js
@@ -129,7 +129,7 @@ function useMediaRecorder({
     }
   }
 
-  async function startRecording() {
+  async function startRecording(timeSlice) {
     if (error) {
       setError(null);
     }
@@ -151,7 +151,7 @@ function useMediaRecorder({
       );
       mediaRecorder.current.addEventListener('stop', handleStop);
       mediaRecorder.current.addEventListener('error', handleError);
-      mediaRecorder.current.start();
+      mediaRecorder.current.start(timeSlice);
       setStatus('recording');
       onStart();
     }

--- a/readme.md
+++ b/readme.md
@@ -114,7 +114,7 @@ Creates a custom media recorder object using the [MediaRecorder API](https://dev
 |stopRecording|`function`|End a recording.
 |getMediaStream|`function`|Request for a media source. Camera, mic and/or screen access.
 |clearMediaStream|`function`|Resets the media stream object to `null`.
-|startRecording|`function`|Begin a recording.
+|startRecording|`function(timeSlice?)`|Begin a recording. Optional argument `timeSlice` controls [chunk size](https://developer.mozilla.org/en-US/docs/Web/API/MediaRecorder/start#parameters).
 |pauseRecording|`function`|Stop without ending a recording allowing the recording to continue later.
 |resumeRecording|`function`|Continue a recording from a previous pause.
 |muteAudio|`function`|Disable audio.


### PR DESCRIPTION
Adding support for `timeSlice` parameter on [`MediaRecorder.start`](https://developer.mozilla.org/en-US/docs/Web/API/MediaRecorder/start#parameters)