### PR TITLE
Add MediaDevices undefined guard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,5 @@ Icon
 Network Trash Folder
 Temporary Items
 .apdis
+
+.idea

--- a/index.js
+++ b/index.js
@@ -13,7 +13,8 @@ function isObject(o) {
  * @param {MediaStreamConstraints} mediaType
  */
 function validateMediaTrackConstraints(mediaType) {
-  let supportedMediaConstraints = navigator.mediaDevices.getSupportedConstraints();
+  let supportedMediaConstraints = navigator.mediaDevices
+      && navigator.mediaDevices.getSupportedConstraints() || {};
   let unSupportedMediaConstraints = Object.keys(mediaType).filter(
     constraint => !supportedMediaConstraints[constraint]
   );


### PR DESCRIPTION
`navigator.mediaDevices` is not yet implemented in Safari, which crashes the component when trying to initialize.
Added a guard that prevents it