### PR TITLE
clearMediaBlob function

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -27,6 +27,7 @@ export interface MediaRecorderHookOptions {
   stopRecording: () => void;
   getMediaStream: () => Promise<void>;
   clearMediaStream: () => void;
+  clearMediaBlob: () => void;
   startRecording: (timeSlice?: number) => void;
   pauseRecording: () => void;
   resumeRecording: () => void;

--- a/index.js
+++ b/index.js
@@ -65,6 +65,7 @@ const noop = () => {};
  * @property {Function} stopRecording,
  * @property {Function} getMediaStream,
  * @property {Function} clearMediaStream,
+ * @property {Function} clearMediaBlob,
  * @property {Function} startRecording,
  * @property {Function} pauseRecording,
  * @property {Function} resumeRecording,
@@ -234,6 +235,10 @@ function useMediaRecorder({
     }
   }
 
+  function clearMediaBlob() {
+    cacheMediaBlob(null);
+  }
+
   React.useEffect(() => {
     if (!window.MediaRecorder) {
       throw new ReferenceError(
@@ -275,6 +280,7 @@ function useMediaRecorder({
     pauseRecording,
     resumeRecording,
     clearMediaStream,
+    clearMediaBlob,
     muteAudio: () => muteAudio(true),
     unMuteAudio: () => muteAudio(false),
     get liveStream() {

--- a/index.test.js
+++ b/index.test.js
@@ -12,6 +12,7 @@ test('hook options', t => {
     status,
     getMediaStream,
     clearMediaStream,
+    clearMediaBlob,
     muteAudio,
     unMuteAudio,
     startRecording,
@@ -27,6 +28,7 @@ test('hook options', t => {
   t.false(isAudioMuted);
   t.true(typeof getMediaStream === 'function');
   t.true(typeof clearMediaStream === 'function');
+  t.true(typeof clearMediaBlob === 'function');
   t.true(typeof muteAudio === 'function');
   t.true(typeof unMuteAudio === 'function');
   t.true(typeof startRecording === 'function');

--- a/readme.md
+++ b/readme.md
@@ -114,6 +114,7 @@ Creates a custom media recorder object using the [MediaRecorder API](https://dev
 |stopRecording|`function`|End a recording.
 |getMediaStream|`function`|Request for a media source. Camera, mic and/or screen access.
 |clearMediaStream|`function`|Resets the media stream object to `null`.
+|clearMediaBlob|`function`|Resets the recorded media object to `null`.
 |startRecording|`function(timeSlice?)`|Begin a recording. Optional argument `timeSlice` controls [chunk size](https://developer.mozilla.org/en-US/docs/Web/API/MediaRecorder/start#parameters).
 |pauseRecording|`function`|Stop without ending a recording allowing the recording to continue later.
 |resumeRecording|`function`|Continue a recording from a previous pause.


### PR DESCRIPTION
when i use the use-media-recorder i will need to clear my recorded media, and i don't see anything for it !!
i added this function and update the tests, interface and readme file
check it, if need more thing ... add to it
and add this feature for this library