### PR TITLE
Return all tracks in media stream instead of video only

### DIFF
--- a/index.js
+++ b/index.js
@@ -292,7 +292,7 @@ function useMediaRecorder({
     unMuteAudio: () => muteAudio(false),
     get liveStream() {
       if (mediaStream.current) {
-        return new MediaStream(mediaStream.current.getVideoTracks());
+        return new MediaStream(mediaStream.current.getTracks());
       }
       return null;
     }


### PR DESCRIPTION
`liveStream` currently doesn't expose all tracks, but only video ones. This is a problem if you want to work with audio tracks. The idea behind this PR is to make `liveStream` return all tracks it has embedded into its mediaStream, regardless of its nature.