### PR TITLE
fix: :bug: fix accessing media stream if component was already unmount

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,10 +92,13 @@ function useMediaRecorder({
   let mediaChunks = React.useRef([]);
   let mediaStream = React.useRef(null);
   let mediaRecorder = React.useRef(null);
+  let isMount = React.useRef(true);
   let [status, setStatus] = React.useState('idle');
   let [errorCache, cacheError] = React.useState(null);
   let [mediaBlobCache, cacheMediaBlob] = React.useState(null);
   let [isAudioMutedCache, cacheIsAudioMuted] = React.useState(false);
+
+  React.useEffect(() => () => (isMount.current = false), []);
 
   async function getMediaStream() {
     if (errorCache) {
@@ -137,6 +140,10 @@ function useMediaRecorder({
     } catch (err) {
       cacheError(err);
       setStatus('failed');
+    }
+
+    if (!isMount.current) {
+      clearMediaStream();
     }
   }
 


### PR DESCRIPTION
## Description

Since the `getMediaStream` method tries to get the user media stream asynchronously, there is a chance to request it when the `mediaRecorder` was already unmounted. That leads to accessing the camera of the device infinitely when the `mediaRecorder` was already destroyed.

## Steps to reproduce
1. Access this [sandbox](https://codesandbox.io/s/screen-recorder-forked-od6y1s?file=/src/App.js) with the current hook implementation from the Chrome browser.
2. Click the "Press me" button and allow access to the camera.
3. Click the "Press me" button to disable the video.
4. Click the "Press me" button as fast as possible in order to trigger the bug.
5. Check whether the component has been unmounted (log in console).
6. Red indicator within the open tab should still signal about accessing the camera as well as a green indicator near the camera (for MacBook laptops).
