### PR TITLE
feat: :sparkles: add returning of requested media stream instance

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,7 +105,7 @@ function useMediaRecorder({
     setStatus('acquiring_media');
     if(customMediaStream) {
       mediaStream.current = customMediaStream;
-      return
+      return customMediaStream;
     }
     try {
       let stream;
@@ -132,6 +132,8 @@ function useMediaRecorder({
 
       mediaStream.current = stream;
       setStatus('ready');
+
+      return stream;
     } catch (err) {
       cacheError(err);
       setStatus('failed');

--- a/readme.md
+++ b/readme.md
@@ -113,7 +113,7 @@ Creates a custom media recorder object using the [MediaRecorder API](https://dev
 |mediaBlob|`Blob`|Raw media data.
 |isAudioMuted|`boolean`|Indicates whether audio is active/inactive.
 |stopRecording|`function`|End a recording.
-|getMediaStream|`function`|Request for a media source. Camera, mic and/or screen access.
+|getMediaStream|`function`|Request for a media source. Camera, mic and/or screen access. Returns instance of requested media source or `customMediaStream` if was provided in initializing.
 |clearMediaStream|`function`|Resets the media stream object to `null`.
 |clearMediaBlob|`function`|Resets the media blob to `null`.
 |startRecording|`function(timeSlice?)`|Begin a recording. Optional argument `timeSlice` controls [chunk size](https://developer.mozilla.org/en-US/docs/Web/API/MediaRecorder/start#parameters).


### PR DESCRIPTION
### Description

This PR is a logical continuation of that [one](https://github.com/wmik/use-media-recorder/pull/23).
PR is intended to provide more flexibility and freedom in control over the requested media streams if there is a such need.

**A bit more context:**
The idea is that once we requested the stream we want to get exactly this instance back and take control over it. It allows us to clean the stream manually whenever there is a need. At least it can be a temporary solution.
LiveStream doesn't help us in that since it returns stream dynamically depending on the set internal state and can respond with a requested again and already overwritten stream.