### PR TITLE
fix: :adhesive_bandage: fix getMediaStream method type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -26,7 +26,7 @@ export interface MediaRecorderHookOptions {
   mediaBlob: Blob | null;
   isAudioMuted: boolean;
   stopRecording: () => void;
-  getMediaStream: () => Promise<void>;
+  getMediaStream: () => Promise<MediaStream>;
   clearMediaStream: () => void;
   clearMediaBlob: () => void;
   startRecording: (timeSlice?: number) => Promise<void>;


### PR DESCRIPTION
## Description

- Fixed type of `getMediaStream` method after introducing the following [PR](https://github.com/wmik/use-media-recorder/pull/24)
