### PR TITLE
Return same liveStream instance on re-render

### DIFF
--- a/index.js
+++ b/index.js
@@ -288,12 +288,7 @@ function useMediaRecorder({
     clearMediaBlob,
     muteAudio: () => muteAudio(true),
     unMuteAudio: () => muteAudio(false),
-    get liveStream() {
-      if (mediaStream.current) {
-        return new MediaStream(mediaStream.current.getVideoTracks());
-      }
-      return null;
-    }
+    liveStream: mediaStream.current,
   };
 }
 


### PR DESCRIPTION
I'm not sure why a wrapper liveStream instance is created from the existing mediaStream. It results in a new stream, which causes flickering when the component re-renders